### PR TITLE
Add configured XmlEncoder to allow encoding without prolog

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Scala 2.12 and 2.13 are supported. Support for Scala 2.11 may be implemented on 
 Add phobos-core to your dependencies:
 
 ```
-libraryDependencies += "ru.tinkoff" %% "phobos-core" % "0.3.1"
+libraryDependencies += "ru.tinkoff" %% "phobos-core" % "0.4.0"
 ```
 
 Then try this code out in `sbt console` or in a separate source file:
@@ -65,7 +65,7 @@ Performance details can be found out in [phobos-benchmark repository](https://gi
 There are several additional modules for some specific cases. 
 These modules could be added with command below:
 ```
-libraryDependencies += "ru.tinkoff" %% "phobos-<module>" % "0.3.1"
+libraryDependencies += "ru.tinkoff" %% "phobos-<module>" % "0.4.0"
 ```
 Where `<module>` is module name.
 

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/encoding/XmlEncoder.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/encoding/XmlEncoder.scala
@@ -49,7 +49,7 @@ trait XmlEncoder[A] {
     factory.setProperty("javax.xml.stream.isRepairingNamespaces", true)
     val sw = factory.createXMLStreamWriter(os, config.encoding).asInstanceOf[XMLStreamWriter2]
     if (config.writeProlog) {
-      sw.writeStartDocument(config.version, config.encoding)
+      sw.writeStartDocument(config.encoding, config.version)
     }
     elementencoder.encodeAsElement(a, sw, localname, namespaceuri)
     if (config.writeProlog) {

--- a/modules/core/src/test/scala/ru/tinkoff/phobos/XmlEncoderTest.scala
+++ b/modules/core/src/test/scala/ru/tinkoff/phobos/XmlEncoderTest.scala
@@ -1,0 +1,17 @@
+package ru.tinkoff.phobos
+
+import org.scalatest.{Matchers, WordSpec}
+import ru.tinkoff.phobos.annotations.XmlCodec
+import ru.tinkoff.phobos.encoding.XmlEncoder
+
+class XmlEncoderTest extends WordSpec with Matchers {
+  "XmlEncoder with config" should {
+    "ignore prolog if configured" in {
+      @XmlCodec("Foo")
+      final case class Foo(a: Int, b: String, c: Double)
+
+      XmlEncoder[Foo].encodeWithConfig(Foo(1, "abc", 1.0), XmlEncoder.defaultConfig.withoutProlog) shouldBe
+        "<Foo><a>1</a><b>abc</b><c>1.0</c></Foo>"
+    }
+  }
+}

--- a/modules/core/src/test/scala/ru/tinkoff/phobos/XmlEncoderTest.scala
+++ b/modules/core/src/test/scala/ru/tinkoff/phobos/XmlEncoderTest.scala
@@ -13,5 +13,21 @@ class XmlEncoderTest extends WordSpec with Matchers {
       XmlEncoder[Foo].encodeWithConfig(Foo(1, "abc", 1.0), XmlEncoder.defaultConfig.withoutProlog) shouldBe
         "<Foo><a>1</a><b>abc</b><c>1.0</c></Foo>"
     }
+
+    "not ignore prolog by default" in {
+      @XmlCodec("Foo")
+      final case class Foo(a: Int, b: String, c: Double)
+
+      XmlEncoder[Foo].encodeWithConfig(Foo(1, "abc", 1.0), XmlEncoder.defaultConfig) shouldBe
+        "<?xml version='1.0' encoding='UTF-8'?><Foo><a>1</a><b>abc</b><c>1.0</c></Foo>"
+    }
+
+    "overwrite prolog information if configured" in {
+      @XmlCodec("Foo")
+      final case class Foo(a: Int, b: String, c: Double)
+
+      XmlEncoder[Foo].encodeWithConfig(Foo(1, "abc", 1.0), XmlEncoder.XmlEncoderConfig("UTF-16", "1.1", true)) shouldBe
+        "<?xml version='1.1' encoding='UTF-16'?><Foo><a>1</a><b>abc</b><c>1.0</c></Foo>"
+    }
   }
 }

--- a/publish.sbt
+++ b/publish.sbt
@@ -1,6 +1,6 @@
 import Publish._
 
-publishVersion := "0.3.1"
+publishVersion := "0.4.0"
 
 ThisBuild / organization := "ru.tinkoff"
 ThisBuild / version := {


### PR DESCRIPTION
This PR add ability to configure XmlEncoder. At the moment only configuring prolog is implemented, buy config is free for extention.

For example,
```scala
@XmlCodec("Foo")
final case class Foo(a: Int, b: String, c: Double)

val foo = Foo(1, "abc", 1.0)

XmlEncoder[Foo].encodeWithConfig(foo, XmlEncoder.defaultConfig.withoutProlog)
```
will result to 
```xml
<Foo><a>1</a><b>abc</b><c>1.0</c></Foo>
```
instead of default
```xml
<?xml version='1.0' encoding='UTF-8'?>
<Foo><a>1</a><b>abc</b><c>1.0</c></Foo>
```