### PR TITLE
Fix exceptions being thrown when invalid XML is encountered

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 ThisBuild / name := "phobos"
 
-ThisBuild / scalaVersion := "2.13.1"
+ThisBuild / scalaVersion := "2.13.3"
 
-lazy val supportedVersions = List("2.12.10", "2.13.1")
+lazy val supportedVersions = List("2.12.11", "2.13.2", "2.13.3")
 
 lazy val commonDependencies =
   libraryDependencies ++= List(

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/XmlDecoder.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/XmlDecoder.scala
@@ -3,23 +3,23 @@ package ru.tinkoff.phobos.decoding
 import cats.Foldable
 import javax.xml.stream.XMLStreamConstants
 import cats.syntax.option._
-import com.fasterxml.aalto.AsyncByteArrayFeeder
+import com.fasterxml.aalto.{AsyncByteArrayFeeder, WFCException}
 import com.fasterxml.aalto.async.{AsyncByteArrayScanner, AsyncStreamReaderImpl}
 import com.fasterxml.aalto.stax.InputFactoryImpl
 import ru.tinkoff.phobos.Namespace
 import ru.tinkoff.phobos.decoding.XmlDecoder.createStreamReader
 
 /**
- * Typeclass for decoding XML document to an A value.
- *
- * XmlDecoder instance must exist only for types which are decoded as XML documents (only for root elements).
- *
- * XmlDecoder instance can be created
- *  - from ElementDecoder using functions in XmlDecoder object
- *  - by macros from ru.tinkoff.phobos.derivation.semiauto package
- *
- * This typeclass wraps ElementDecoder[A] and provides element name and Cursor.
- */
+  * Typeclass for decoding XML document to an A value.
+  *
+  * XmlDecoder instance must exist only for types which are decoded as XML documents (only for root elements).
+  *
+  * XmlDecoder instance can be created
+  *  - from ElementDecoder using functions in XmlDecoder object
+  *  - by macros from ru.tinkoff.phobos.derivation.semiauto package
+  *
+  * This typeclass wraps ElementDecoder[A] and provides element name and Cursor.
+  */
 trait XmlDecoder[A] {
   val localname: String
   val namespaceuri: Option[String]
@@ -34,12 +34,17 @@ trait XmlDecoder[A] {
     sr.getInputFeeder.feedInput(bytes, 0, bytes.length)
     sr.getInputFeeder.endOfInput()
     val cursor = new Cursor(sr)
-    do {
-      cursor.next()
-    } while (cursor.getEventType == XMLStreamConstants.DTD || cursor.getEventType == XMLStreamConstants.START_DOCUMENT)
-    elementdecoder
-      .decodeAsElement(cursor, localname, namespaceuri)
-      .result(cursor.history)
+    try {
+      do {
+        cursor.next()
+      } while (cursor.getEventType == XMLStreamConstants.DTD || cursor.getEventType == XMLStreamConstants.START_DOCUMENT)
+      elementdecoder
+        .decodeAsElement(cursor, localname, namespaceuri)
+        .result(cursor.history)
+    } catch {
+      case e: WFCException =>
+        Left(DecodingError(e.getMessage, cursor.history))
+    }
   }
 
   def decodeFromFoldable[F[_]: Foldable](f: F[Array[Byte]], charset: String = "UTF-8"): Either[DecodingError, A] = {
@@ -78,8 +83,8 @@ object XmlDecoder {
   def fromElementDecoder[A](localName: String, namespaceUri: Option[String])(
       implicit elementDecoder: ElementDecoder[A]): XmlDecoder[A] =
     new XmlDecoder[A] {
-      val localname: String = localName
-      val namespaceuri: Option[String] = namespaceUri
+      val localname: String                 = localName
+      val namespaceuri: Option[String]      = namespaceUri
       val elementdecoder: ElementDecoder[A] = elementDecoder
     }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.2.8
+sbt.version = 1.3.13


### PR DESCRIPTION
Hey there, thank you for this amazing library - it makes XML parsing a lot more fun than it usually is 😆 
I ran into #26 and I really wanted to fix it. I noticed this is fairly low level with the cursor code so I ended up just using a try-catch to fix the problem. I'm very open to your suggestions if you want it done another way (using Try or something like that)

**Updates**
- Update SBT to 1.3.13
- Update Scala to 2.13.3 and keep support for 2.13.2 and 2.12.11

Closes #26 