### PR TITLE
Default decoders and element name discriminators

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Scala 2.12 and 2.13 are supported. Support for Scala 2.11 may be implemented on 
 Add phobos-core to your dependencies:
 
 ```
-libraryDependencies += "ru.tinkoff" %% "phobos-core" % "0.7.0"
+libraryDependencies += "ru.tinkoff" %% "phobos-core" % "0.8.0"
 ```
 
 Then try this code out in `sbt console` or in a separate source file:
@@ -67,7 +67,7 @@ Performance details can be found out in [phobos-benchmark repository](https://gi
 There are several additional modules for some specific cases. 
 These modules could be added with command below:
 ```
-libraryDependencies += "ru.tinkoff" %% "phobos-<module>" % "0.7.0"
+libraryDependencies += "ru.tinkoff" %% "phobos-<module>" % "0.8.0"
 ```
 Where `<module>` is module name.
 

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/configured/ElementCodecConfig.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/configured/ElementCodecConfig.scala
@@ -5,7 +5,8 @@ final case class ElementCodecConfig(
     transformElementNames: String => String,
     transformConstructorNames: String => String,
     discriminatorLocalName: String,
-    discriminatorNamespace: Option[String]
+    discriminatorNamespace: Option[String],
+    useElementNameAsDiscriminator: Boolean,
 ) {
   def withElementsRenamed(transform: String => String): ElementCodecConfig =
     copy(transformElementNames = transform)
@@ -21,9 +22,20 @@ final case class ElementCodecConfig(
 
   def withDiscriminator(localName: String, namespace: Option[String]): ElementCodecConfig =
     copy(discriminatorLocalName = localName, discriminatorNamespace = namespace)
+
+  def usingElementNamesAsDiscriminator: ElementCodecConfig =
+    copy(useElementNameAsDiscriminator = true)
+
 }
 
 object ElementCodecConfig {
   val default: ElementCodecConfig =
-    ElementCodecConfig(identity, identity, identity, "type", Some("http://www.w3.org/2001/XMLSchema-instance"))
+    ElementCodecConfig(
+      transformAttributeNames = identity,
+      transformElementNames = identity,
+      transformConstructorNames = identity,
+      discriminatorLocalName = "type",
+      discriminatorNamespace = Some("http://www.w3.org/2001/XMLSchema-instance"),
+      useElementNameAsDiscriminator = false,
+    )
 }

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/derivation/DecoderDerivation.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/derivation/DecoderDerivation.scala
@@ -378,9 +378,9 @@ class DecoderDerivation(ctx: blackbox.Context) extends Derivation(ctx) {
 object DecoderDerivation {
   sealed trait DecoderState
   object DecoderState {
-    case object New                                       extends DecoderState
-    case object DecodingSelf                              extends DecoderState
-    case class DecodingElement(name: String)             extends DecoderState
+    case object New                                                                 extends DecoderState
+    case object DecodingSelf                                                        extends DecoderState
+    case class DecodingElement(name: String)                                        extends DecoderState
     case class IgnoringElement(name: String, namespace: Option[String], depth: Int) extends DecoderState
   }
 }

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/derivation/DecoderDerivation.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/derivation/DecoderDerivation.scala
@@ -103,12 +103,13 @@ class DecoderDerivation(ctx: blackbox.Context) extends Derivation(ctx) {
                      classConstructionForEnum: Tree,
                      decoderConstructionParam: Tree)
 
-    val allParams: mutable.ListBuffer[Param]       = mutable.ListBuffer.empty
-    val decodeAttributes: mutable.ListBuffer[Tree] = mutable.ListBuffer.empty
-    val decodeElements: mutable.ListBuffer[Tree]   = mutable.ListBuffer.empty
-    val decodeText: mutable.ListBuffer[Tree]       = mutable.ListBuffer.empty
-    val elementNames: mutable.ListBuffer[Tree]     = mutable.ListBuffer.empty
-    val preAssignments                             = new ListBuffer[Tree]
+    val allParams        = mutable.ListBuffer.empty[Param]
+    val decodeAttributes = mutable.ListBuffer.empty[Tree]
+    val decodeElements   = mutable.ListBuffer.empty[Tree]
+    val decodeText       = mutable.ListBuffer.empty[Tree]
+    val decodeDefault    = mutable.ListBuffer.empty[(Tree, Tree) => Tree]
+    val elementNames     = mutable.ListBuffer.empty[Tree]
+    val preAssignments   = new ListBuffer[Tree]
 
     params.foreach { param =>
       val tempName   = TermName(c.freshName(param.localName))
@@ -200,10 +201,45 @@ class DecoderDerivation(ctx: blackbox.Context) extends Derivation(ctx) {
             )
           )
           decodeText.append(q"$tempName = $tempName.decodeAsText(cursor)")
+
+        case ParamCategory.default =>
+          val defaultDecoder = appliedType(elementDecoderType, param.paramType)
+          val path           = ProductType(param.localName, weakTypeOf[T].toString)
+          val frame          = stack.Frame(path, appliedType(elementDecoderType, weakTypeOf[T]), assignedName)
+          val derivedImplicit = stack.recurse(frame, defaultDecoder) {
+            typeclassTree(stack)(param.paramType, elementDecoderType)
+          }
+          val ref      = TermName(c.freshName("paramTypeclass"))
+          val assigned = deferredVal(ref, defaultDecoder, derivedImplicit)
+
+          preAssignments.append(assigned)
+
+          allParams.append(
+            Param(
+              decoderParamAssignment = q"private[this] val $paramName: $derivationPkg.CallByNeed[$defaultDecoder]",
+              defaultValue = q"$derivationPkg.CallByNeed[$defaultDecoder]($ref)",
+              goAssignment = q"var $tempName: $defaultDecoder = $paramName.value",
+              decoderConstructionParam = q"$derivationPkg.CallByNeed[$defaultDecoder]($tempName)",
+              classConstructionForEnum = fq"$forName <- $tempName.result(cursor.history)",
+              classConstructorParam = q"$forName"
+            ))
+
+          decodeDefault.append((elementName: Tree, elementNamespace: Tree) => q"""
+              $tempName = $tempName.decodeAsElement(cursor, $elementName, $elementNamespace)
+              if ($tempName.isCompleted) {
+                $tempName.result(cursor.history) match {
+                  case $scalaPkg.Right(_) => go($decoderStateObj.DecodingSelf)
+                  case $scalaPkg.Left(error) => new $decodingPkg.ElementDecoder.FailedDecoder[$classType](error)
+                }
+              } else {
+                go($decoderStateObj.IgnoringElement($elementName, $elementNamespace, 0))
+              }
+             """)
       }
     }
 
-    val parseTextParam = decodeText.headOption.getOrElse(q"")
+    val parseTextParam    = decodeText.headOption.getOrElse(q"")
+    val parseDefaultParam = decodeDefault.headOption
     val classConstruction = if (allParams.nonEmpty) {
       q"(for (..${allParams.map(_.classConstructionForEnum)}) yield new $classType(..${allParams.map(_.classConstructorParam)}))"
     } else {
@@ -246,15 +282,22 @@ class DecoderDerivation(ctx: blackbox.Context) extends Derivation(ctx) {
                 $parseTextParam
                 if (cursor.isStartElement) {
                   cursor.getLocalName match {
-                    case ..${decodeElements :+
-      cq"""field =>
-                        cursor.next()
-                        go($decoderStateObj.IgnoringElement(field, 0))
-                      """}
+                    case ..$decodeElements
+                    case ${parseDefaultParam.fold(cq"""
+                        _ =>
+                          val state = $decoderStateObj.IgnoringElement(cursor.getLocalName, Option(cursor.getNamespaceURI).filter(_.nonEmpty), 0)
+                          cursor.next()
+                          go(state)
+                        """)(handler => cq"""
+                        _ =>
+                          val name = cursor.getLocalName
+                          val namespace = Option(cursor.getNamespaceURI).filter(_.nonEmpty)
+                          ${handler(q"name", q"namespace")}
+                        """)}
                   }
                 } else if (cursor.isEndElement) {
                   cursor.getLocalName match {
-                    case field if field == localName =>
+                    case name if name == localName =>
                       $classConstruction match {
                         case $scalaPkg.Right(result) =>
                           cursor.next()
@@ -273,26 +316,28 @@ class DecoderDerivation(ctx: blackbox.Context) extends Derivation(ctx) {
                   go($decoderStateObj.DecodingSelf)
                 }
 
-              case $decoderStateObj.DecodingElement(field) =>
-                field match {
+              case $decoderStateObj.DecodingElement(name) =>
+                name match {
                   case ..$decodeElements
                 }
 
-              case $decoderStateObj.IgnoringElement(field, depth) =>
-                if (cursor.isEndElement && cursor.getLocalName == field) {
-                  cursor.next()
-                  if (depth == 0) {
-                    go($decoderStateObj.DecodingSelf)
+              case $decoderStateObj.IgnoringElement(name, namespace, depth) =>
+                ${parseDefaultParam.fold[Tree](q"""
+                  if (cursor.isEndElement && cursor.getLocalName == name && cursor.getNamespaceURI == namespace.getOrElse("")) {
+                    cursor.next()
+                    if (depth == 0) {
+                      go($decoderStateObj.DecodingSelf)
+                    } else {
+                      go($decoderStateObj.IgnoringElement(name, namespace, depth - 1))
+                    }
+                  } else if (cursor.isStartElement && cursor.getLocalName == name && cursor.getNamespaceURI == namespace.getOrElse("")) {
+                    cursor.next()
+                    go($decoderStateObj.IgnoringElement(name, namespace, depth + 1))
                   } else {
-                    go($decoderStateObj.IgnoringElement(field, depth - 1))
+                    cursor.next()
+                    go(currentState)
                   }
-                } else if (cursor.isStartElement && cursor.getLocalName == field) {
-                  cursor.next()
-                  go($decoderStateObj.IgnoringElement(field, depth + 1))
-                } else {
-                  cursor.next()
-                  go(currentState)
-                }
+                """)(handler => handler(q"name", q"namespace"))}
             }
           }
 
@@ -335,7 +380,7 @@ object DecoderDerivation {
   object DecoderState {
     case object New                                       extends DecoderState
     case object DecodingSelf                              extends DecoderState
-    case class DecodingElement(field: String)             extends DecoderState
-    case class IgnoringElement(field: String, depth: Int) extends DecoderState
+    case class DecodingElement(name: String)             extends DecoderState
+    case class IgnoringElement(name: String, namespace: Option[String], depth: Int) extends DecoderState
   }
 }

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/derivation/ParamCategory.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/derivation/ParamCategory.scala
@@ -6,4 +6,5 @@ object ParamCategory {
   case object element extends ParamCategory
   case object attribute extends ParamCategory
   case object text extends ParamCategory
+  case object default extends ParamCategory
 }

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/syntax.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/syntax.scala
@@ -12,9 +12,17 @@ object syntax {
   final class attr() extends StaticAnnotation
 
   /**
-    * Case class params with @text annotation are treated as text inside elements.
+    * Case class param with @text annotation is treated as text inside elements.
     */
   final class text() extends StaticAnnotation
+
+  /**
+    * Case class param with @default annotation is used for decoding elements
+    * which do not fit for other params.
+    *
+    * Params with this annotation are ignored during decoding.
+    */
+  final class default() extends StaticAnnotation
 
   /**
     * Annotation @xmlns adds namespace to case class parameter if implicit Namespace[T] exists.

--- a/modules/core/src/test/scala/ru/tinkoff/phobos/DecoderDerivationSuit.scala
+++ b/modules/core/src/test/scala/ru/tinkoff/phobos/DecoderDerivationSuit.scala
@@ -3,6 +3,7 @@ package ru.tinkoff.phobos
 import cats.syntax.option._
 import cats.instances.list._
 import org.scalatest._
+import ru.tinkoff.phobos.SealedClasses.{Animal, Cat, Cow, Dog}
 import ru.tinkoff.phobos.annotations.{ElementCodec, XmlCodec, XmlCodecNs, XmlnsDef}
 import ru.tinkoff.phobos.decoding.{AttributeDecoder, ElementDecoder, TextDecoder, XmlDecoder}
 import ru.tinkoff.phobos.syntax._
@@ -847,6 +848,32 @@ class DecoderDerivationSuit extends WordSpec with Matchers {
       notTransformCustomDiscriminatorValues(pure)
     "not transform custom discriminator values async" in
       notTransformCustomDiscriminatorValues(fromIterable)
+
+    def useElementNameAsDiscriminatorIfConfigured(toList: String => List[Array[Byte]]): Assertion = {
+      @XmlCodec("zoo")
+      case class Zoo(@default animals: List[Animal])
+      val string = """<?xml version='1.0' encoding='UTF-8'?>
+                      | <zoo>
+                      |   <cow>
+                      |     <moo>12.432</moo>
+                      |   </cow>
+                      |   <cat>
+                      |     <meow>meow</meow>
+                      |   </cat>
+                      |   <dog>
+                      |     <woof>1234</woof>
+                      |   </dog>
+                      |   <cat>
+                      |     <meow>nya</meow>
+                      |   </cat>
+                      | </zoo>
+                    """.stripMargin
+      val zoo = Zoo(List(Cow(12.432), Cat("meow"), Dog(1234), Cat("nya")))
+      XmlDecoder[Zoo].decodeFromFoldable(toList(string)) shouldBe Right(zoo)
+    }
+
+    "use element name as discriminator if configured sync" in useElementNameAsDiscriminatorIfConfigured(pure)
+    "use element name as discriminator if configured async" in useElementNameAsDiscriminatorIfConfigured(fromIterable)
   }
 
   "Decoder derivation with namespaces" should {

--- a/modules/core/src/test/scala/ru/tinkoff/phobos/EncoderDerivationSuit.scala
+++ b/modules/core/src/test/scala/ru/tinkoff/phobos/EncoderDerivationSuit.scala
@@ -2,6 +2,7 @@ package ru.tinkoff.phobos
 
 import cats.syntax.option._
 import org.scalatest._
+import ru.tinkoff.phobos.SealedClasses.{Animal, Cat, Cow, Dog}
 import ru.tinkoff.phobos.annotations.{ElementCodec, XmlCodec, XmlCodecNs, XmlnsDef}
 import ru.tinkoff.phobos.encoding.{AttributeEncoder, ElementEncoder, TextEncoder, XmlEncoder}
 import ru.tinkoff.phobos.testString._
@@ -573,6 +574,30 @@ class EncoderDerivationSuit extends WordSpec with Matchers {
               | </fish>
             """.stripMargin.minimized
       )
+    }
+
+    "use element name as discriminator if configured" in {
+      @XmlCodec("zoo")
+      case class Zoo(@default animals: List[Animal])
+      val string =
+        """<?xml version='1.0' encoding='UTF-8'?>
+          | <zoo>
+          |   <cow>
+          |     <moo>12.432</moo>
+          |   </cow>
+          |   <cat>
+          |     <meow>meow</meow>
+          |   </cat>
+          |   <dog>
+          |     <woof>1234</woof>
+          |   </dog>
+          |   <cat>
+          |     <meow>nya</meow>
+          |   </cat>
+          | </zoo>
+                    """.stripMargin.minimized
+      val zoo = Zoo(List(Cow(12.432), Cat("meow"), Dog(1234), Cat("nya")))
+      XmlEncoder[Zoo].encode(zoo) shouldBe string
     }
   }
 

--- a/modules/core/src/test/scala/ru/tinkoff/phobos/SealedClasses.scala
+++ b/modules/core/src/test/scala/ru/tinkoff/phobos/SealedClasses.scala
@@ -73,4 +73,17 @@ object SealedClasses {
 
   @ElementCodec
   case class CarcharodonCarcharias(name: String, teethNumber: Long) extends Pisces
+
+
+  @ElementCodec(ElementCodecConfig.default.usingElementNamesAsDiscriminator.withConstructorsRenamed(snakeCase))
+  sealed trait Animal
+
+  @ElementCodec
+  case class Cat(meow: String) extends Animal
+
+  @ElementCodec
+  case class Dog(woof: Int) extends Animal
+
+  @ElementCodec
+  case class Cow(moo: Double) extends Animal
 }

--- a/publish.sbt
+++ b/publish.sbt
@@ -1,6 +1,6 @@
 import Publish._
 
-publishVersion := "0.7.0"
+publishVersion := "0.8.0"
 
 ThisBuild / organization := "ru.tinkoff"
 ThisBuild / version := {


### PR DESCRIPTION
This PR adds two concepts.
## Default element decoders
Default element decoder can now be specified for elements which do not match any of case class parameters. Parameter used for storing these elements must be marked with `@default` annotation. If parameter with `@default` annotation is missing, extra elements will be ignored.

For example, consider following xml document and case class `Foo`. Elements `bar` and `baz` will be decoded into parameters `bar` and `baz`. As elements `default1`, `default2`, `default3` do not match any of `Foo`'s parameters, the default parameter `defaults` will be used. Parameter `defaults` has type of `List[Default]`, so element decoder for this type will be used. See `DecoderDerivationSuit.scala` for real code.
```xml
<?xml version='1.0' encoding='UTF-8'?>
<foo>
  <default1><a>100</a></default1>
  <bar>1</bar>
  <default2><b>default string</b></default2>
  <baz>baz value</baz>
  <default3><c>12.3</c></default3>
</foo>
```
```scala
@ElementCodec
case class Default(a: Option[Int], b: Option[String], c: Option[Double])
@XmlCodec("foo")
case class Foo(bar: Int, baz: String, @default defaults: List[Default])
```
## Element names as discriminators
This feature allows to use element names instead of attributes as type discriminator for sealed traits. This behavior is toggled by `useElementNameAsDiscriminator` flag in `ElementCodecConfig`, default is `false` (using attributes, as before).

Example:
```scala
@ElementCodec(ElementCodecConfig.default.usingElementNamesAsDiscriminator.withConstructorsRenamed(snakeCase))
sealed trait Animal

@ElementCodec
case class Cat(meow: String) extends Animal

@ElementCodec
case class Dog(woof: Int) extends Animal

@ElementCodec
case class Cow(moo: Double) extends Animal

@XmlCodec("zoo")
case class Zoo(@default animals: List[Animal])

// Correspons to xml documnet below
Zoo(List(Cow(12.432), Cat("meow"), Dog(1234), Cat("nya")))
```
```xml
<?xml version='1.0' encoding='UTF-8'?>
 <zoo>
   <cow>
     <moo>12.432</moo>
   </cow>
   <cat>
     <meow>meow</meow>
   </cat>
   <dog>
     <woof>1234</woof>
   </dog>
   <cat>
     <meow>nya</meow>
   </cat>
 </zoo>
```