### PR TITLE
Add default namespaces for elements and attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Scala 2.12 and 2.13 are supported. Support for Scala 2.11 may be implemented on 
 Add phobos-core to your dependencies:
 
 ```
-libraryDependencies += "ru.tinkoff" %% "phobos-core" % "0.8.2"
+libraryDependencies += "ru.tinkoff" %% "phobos-core" % "0.9.0"
 ```
 
 Then try this code out in `sbt console` or in a separate source file:
@@ -67,7 +67,7 @@ Performance details can be found out in [phobos-benchmark repository](https://gi
 There are several additional modules for some specific cases. 
 These modules could be added with command below:
 ```
-libraryDependencies += "ru.tinkoff" %% "phobos-<module>" % "0.8.2"
+libraryDependencies += "ru.tinkoff" %% "phobos-<module>" % "0.9.0"
 ```
 Where `<module>` is module name.
 

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/configured/ElementCodecConfig.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/configured/ElementCodecConfig.scala
@@ -1,5 +1,7 @@
 package ru.tinkoff.phobos.configured
 
+import ru.tinkoff.phobos.Namespace
+
 final case class ElementCodecConfig(
     transformAttributeNames: String => String,
     transformElementNames: String => String,
@@ -7,6 +9,8 @@ final case class ElementCodecConfig(
     discriminatorLocalName: String,
     discriminatorNamespace: Option[String],
     useElementNameAsDiscriminator: Boolean,
+    attributesDefaultNamespace: Option[String] = None,
+    elementsDefaultNamespace: Option[String] = None,
 ) {
   def withElementsRenamed(transform: String => String): ElementCodecConfig =
     copy(transformElementNames = transform)
@@ -25,6 +29,18 @@ final case class ElementCodecConfig(
 
   def usingElementNamesAsDiscriminator: ElementCodecConfig =
     copy(useElementNameAsDiscriminator = true)
+
+  def withAttributesDefaultNamespace(namespace: String): ElementCodecConfig =
+    copy(attributesDefaultNamespace = Some(namespace))
+
+  def withAttributesDefaultNamespace[NS](namespace: NS)(implicit ns: Namespace[NS]): ElementCodecConfig =
+    copy(attributesDefaultNamespace = Some(ns.getNamespace))
+
+  def withElementsDefaultNamespace(namespace: String): ElementCodecConfig =
+    copy(elementsDefaultNamespace = Some(namespace))
+
+  def withElementsDefaultNamespace[NS](namespace: NS)(implicit ns: Namespace[NS]): ElementCodecConfig =
+    copy(elementsDefaultNamespace = Some(ns.getNamespace))
 
 }
 

--- a/publish.sbt
+++ b/publish.sbt
@@ -1,6 +1,6 @@
 import Publish._
 
-publishVersion := "0.8.2"
+publishVersion := "0.9.0"
 
 ThisBuild / organization := "ru.tinkoff"
 ThisBuild / version := {


### PR DESCRIPTION
This PR adds ability to specify default namespace for elements or attributes inside of case class. It helps to avoid copy-pasting `@xmlns` attribute.

Example of this feature:
```scala
@XmlnsDef("http://example.com")
case object xmp

val config =  ElementCodecConfig.default.withElementsDefaultNamespace(xmp)

@XmlCodecNs("bar", xmp, config)
case class Foo(a: Int, b: String, c: Double)

XmlEncoder[Foo].encode(Foo(1, "str", 2.3))
```
```xml
<?xml version='1.0' encoding='UTF-8'?>
<ans1:bar xmlns:ans1="http://example.com">
  <ans1:a>1</ans1:a>
  <ans1:b>str</ans1:b>
  <ans1:c>2.3</ans1:c>
</ans1:bar>

```