### PR TITLE
Allow manual namespace definition

### DIFF
--- a/modules/core/src/main/scala/ru/tinkoff/phobos/configured/ElementCodecConfig.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/configured/ElementCodecConfig.scala
@@ -11,6 +11,7 @@ final case class ElementCodecConfig(
     useElementNameAsDiscriminator: Boolean,
     attributesDefaultNamespace: Option[String] = None,
     elementsDefaultNamespace: Option[String] = None,
+    defineNamespaces: List[String] = Nil,
 ) {
   def withElementsRenamed(transform: String => String): ElementCodecConfig =
     copy(transformElementNames = transform)
@@ -42,6 +43,11 @@ final case class ElementCodecConfig(
   def withElementsDefaultNamespace[NS](namespace: NS)(implicit ns: Namespace[NS]): ElementCodecConfig =
     copy(elementsDefaultNamespace = Some(ns.getNamespace))
 
+  def withNamespaceDefined(namespace: String): ElementCodecConfig =
+    copy(defineNamespaces = namespace :: defineNamespaces)
+
+  def withNamespaceDefined[NS](namespace: NS)(implicit ns: Namespace[NS]): ElementCodecConfig =
+    copy(defineNamespaces = ns.getNamespace :: defineNamespaces)
 }
 
 object ElementCodecConfig {
@@ -53,5 +59,6 @@ object ElementCodecConfig {
       discriminatorLocalName = "type",
       discriminatorNamespace = Some("http://www.w3.org/2001/XMLSchema-instance"),
       useElementNameAsDiscriminator = false,
+      defineNamespaces = Nil,
     )
 }

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/derivation/DecoderDerivation.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/derivation/DecoderDerivation.scala
@@ -92,7 +92,7 @@ class DecoderDerivation(ctx: blackbox.Context) extends Derivation(ctx) {
     """
   }
 
-  def deriveProductCodec[T: c.WeakTypeTag](stack: Stack[c.type])(params: IndexedSeq[CaseClassParam]): Tree = {
+  def deriveProductCodec[T: c.WeakTypeTag](stack: Stack[c.type])(config: Expr[ElementCodecConfig], params: IndexedSeq[CaseClassParam]): Tree = {
 
     val decoderStateObj = q"$derivationPkg.DecoderDerivation.DecoderState"
 

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/derivation/Derivation.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/derivation/Derivation.scala
@@ -33,7 +33,7 @@ private[phobos] abstract class Derivation(val c: blackbox.Context) {
       subtypes: Iterable[SealedTraitSubtype]
   ): Tree
 
-  def deriveProductCodec[T: c.WeakTypeTag](stack: Stack[c.type])(params: IndexedSeq[CaseClassParam]): Tree
+  def deriveProductCodec[T: c.WeakTypeTag](stack: Stack[c.type])(config: Expr[ElementCodecConfig], params: IndexedSeq[CaseClassParam]): Tree
 
   def error(msg: String): Nothing = c.abort(c.enclosingPosition, msg)
 
@@ -199,7 +199,7 @@ private[phobos] abstract class Derivation(val c: blackbox.Context) {
         (attributeParamsNumber, regularParamsNumber, textParamsNumber, defaultParamsNumber) match {
           case (_, _, t, _) if t > 1 => error("Multiple @text parameters are not allowed")
           case (_, _, _, d) if d > 1 => error("Mutiple @default parameters are not allowed")
-          case _                     => deriveProductCodec(stack)(params)
+          case _                     => deriveProductCodec(stack)(config, params)
         }
       } else error(s"$classSymbol is not case class or sealed trait")
     }

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/derivation/EncoderDerivation.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/derivation/EncoderDerivation.scala
@@ -67,7 +67,7 @@ class EncoderDerivation(ctx: blackbox.Context) extends Derivation(ctx) {
     """
   }
 
-  def deriveProductCodec[T: c.WeakTypeTag](stack: Stack[c.type])(params: IndexedSeq[CaseClassParam]): Tree = {
+  def deriveProductCodec[T: c.WeakTypeTag](stack: Stack[c.type])(config: Expr[ElementCodecConfig], params: IndexedSeq[CaseClassParam]): Tree = {
     val assignedName = TermName(c.freshName(s"ElementEncoderTypeclass")).encodedName.toTermName
 
     val scalaPkg = q"_root_.scala"
@@ -134,6 +134,9 @@ class EncoderDerivation(ctx: blackbox.Context) extends Derivation(ctx) {
          namespaceUri: $scalaPkg.Option[$javaPkg.String]
        ): $scalaPkg.Unit = {
          namespaceUri.fold(sw.writeStartElement(localName))(ns => sw.writeStartElement(ns, localName))
+         $config.defineNamespaces.foreach { uri =>
+           if (sw.getNamespaceContext.getPrefix(uri) == null) sw.writeNamespace(uri)
+         }
 
          ..$encodeAttributes
          ..$encodeText

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/encoding/PhobosStreamWriter.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/encoding/PhobosStreamWriter.scala
@@ -230,6 +230,12 @@ final class PhobosStreamWriter(sw: XMLStreamWriter2) extends XMLStreamWriter2 {
   def writeNamespace(prefix: String, namespaceURI: String): Unit =
     sw.writeNamespace(prefix, namespaceURI)
 
+  /**
+   * Writes a namespace to the output stream
+   * Generates unbound prefix in format <code>ans\d+</code> and binds it to URI
+   *
+   * @param namespaceURI the uri to bind the prefix to
+   */
   def writeNamespace(namespaceURI: String): Unit = {
     val nsContext = sw.getNamespaceContext
     if (nsContext.getPrefix(namespaceURI) == null) {

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/encoding/PhobosStreamWriter.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/encoding/PhobosStreamWriter.scala
@@ -7,6 +7,7 @@ import javax.xml.stream.XMLStreamException
 import org.codehaus.stax2.typed.Base64Variant
 import org.codehaus.stax2.{XMLStreamLocation2, XMLStreamReader2, XMLStreamWriter2}
 import org.codehaus.stax2.validation.{ValidationProblemHandler, XMLValidationSchema, XMLValidator}
+import PhobosStreamWriter.prefixBase
 
 final class PhobosStreamWriter(sw: XMLStreamWriter2) extends XMLStreamWriter2 {
 
@@ -229,6 +230,24 @@ final class PhobosStreamWriter(sw: XMLStreamWriter2) extends XMLStreamWriter2 {
   def writeNamespace(prefix: String, namespaceURI: String): Unit =
     sw.writeNamespace(prefix, namespaceURI)
 
+  def writeNamespace(namespaceURI: String): Unit = {
+    val nsContext = sw.getNamespaceContext
+    if (nsContext.getPrefix(namespaceURI) == null) {
+      var left = 1
+      var right = 1
+      while (nsContext.getNamespaceURI(prefixBase + right) != null) {
+        left = right
+        right *= 2
+      }
+      while (left + 1 < right) {
+        val median = (left + right) / 2
+        if (nsContext.getNamespaceURI(prefixBase + median) == null) right = median
+        else left = median
+      }
+      sw.writeNamespace(prefixBase + right, namespaceURI)
+    }
+  }
+
   def writeDefaultNamespace(namespaceURI: String): Unit =
     sw.writeDefaultNamespace(namespaceURI)
 
@@ -294,4 +313,9 @@ final class PhobosStreamWriter(sw: XMLStreamWriter2) extends XMLStreamWriter2 {
 
   def setValidationProblemHandler(h: ValidationProblemHandler): ValidationProblemHandler =
     sw.setValidationProblemHandler(h)
+
+}
+
+object PhobosStreamWriter {
+  val prefixBase = "ans"
 }


### PR DESCRIPTION
This PR allows to manually define namespaces via `ElementCodecConfig`:
```scala
@XmlnsDef("http://example.com")
case object ex

val config = ElementCodecConfig.default.withNamespaceDefined(ex)

@XmlCodec("foo", config)
final case class Foo(@xmlns(ex) a: Int, @xmlns(ex) b: Int, @xmlns(ex) ...)

val foo = Foo(1, 2, ...)

XmlEncoder[Foo].encode(foo)
```
```xml
<?xml version='1.0' encoding='UTF-8'?>
<foo xmlns:ans1="http://example.com">
  <ans1:a>1</ans1:a>
  <ans1:b>2</ans1:b>
  ...
</foo>
```

If namespace from config is already defined, then it won't be defined again:
```scala
@XmlCodecNs("bar", ex)
final case class Bar(foo: Foo)

val bar = Bar(foo)

XmlEncoder[Bar].encode(bar)
```
```xml
<?xml version='1.0' encoding='UTF-8'?>
<ans1:bar xmlns:ans1="http://example.com">
  <foo>
    <ans1:a>1</ans1:a>
    <ans1:b>2</ans1:b>
    ...
  </foo>
</ans1:bar>
```

