### PR TITLE
Close #34: Reuse factories in xml codecs

### DIFF
--- a/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/XmlDecoder.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/XmlDecoder.scala
@@ -69,10 +69,10 @@ trait XmlDecoder[A] {
 }
 
 object XmlDecoder {
+  private lazy val factory = new InputFactoryImpl
 
   def createStreamReader(charset: String): XmlStreamReader = {
-    val inputFactory = new InputFactoryImpl
-    val cfg          = inputFactory.getNonSharedConfig(null, null, null, false, false)
+    val cfg = XmlDecoder.factory.getNonSharedConfig(null, null, null, false, false)
     cfg.setActualEncoding(charset)
     cfg.doReportCData(false)
     new AsyncStreamReaderImpl[AsyncByteArrayFeeder](new AsyncByteArrayScanner(cfg))

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/encoding/XmlEncoder.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/encoding/XmlEncoder.scala
@@ -28,10 +28,9 @@ trait XmlEncoder[A] {
     new String(encodeToBytes(a, charset), charset)
 
   def encodeToBytes(a: A, charset: String = "UTF-8"): Array[Byte] = {
-    val os      = new ByteArrayOutputStream
-    val factory = new OutputFactoryImpl
-    factory.setProperty("javax.xml.stream.isRepairingNamespaces", true)
-    val sw = new PhobosStreamWriter(factory.createXMLStreamWriter(os, charset).asInstanceOf[XMLStreamWriter2])
+    val os = new ByteArrayOutputStream
+    val sw =
+      new PhobosStreamWriter(XmlEncoder.factory.createXMLStreamWriter(os, charset).asInstanceOf[XMLStreamWriter2])
     sw.writeStartDocument()
     elementencoder.encodeAsElement(a, sw, localname, namespaceuri)
     sw.writeEndDocument()
@@ -44,10 +43,9 @@ trait XmlEncoder[A] {
     new String(encodeToBytesWithConfig(a, config), config.encoding)
 
   def encodeToBytesWithConfig(a: A, config: XmlEncoderConfig): Array[Byte] = {
-    val os      = new ByteArrayOutputStream
-    val factory = new OutputFactoryImpl
-    factory.setProperty("javax.xml.stream.isRepairingNamespaces", true)
-    val sw = new PhobosStreamWriter(factory.createXMLStreamWriter(os, config.encoding).asInstanceOf[XMLStreamWriter2])
+    val os = new ByteArrayOutputStream
+    val sw =
+      new PhobosStreamWriter(XmlEncoder.factory.createXMLStreamWriter(os, config.encoding).asInstanceOf[XMLStreamWriter2])
     if (config.writeProlog) {
       sw.writeStartDocument(config.encoding, config.version)
     }
@@ -63,6 +61,12 @@ trait XmlEncoder[A] {
 }
 
 object XmlEncoder {
+
+  private lazy val factory = {
+    val factory = new OutputFactoryImpl
+    factory.setProperty("javax.xml.stream.isRepairingNamespaces", true)
+    factory
+  }
 
   def apply[A](implicit instance: XmlEncoder[A]): XmlEncoder[A] = instance
 


### PR DESCRIPTION
This PR should slightly improve performance of `encode`/`decode` calls in `XmlEncoder`/`XmlDecoder`