### PR TITLE
More detailed error messages

### DIFF
--- a/modules/ast/src/main/scala/ru/tinkoff/phobos/traverse/GenericElementDecoder.scala
+++ b/modules/ast/src/main/scala/ru/tinkoff/phobos/traverse/GenericElementDecoder.scala
@@ -123,8 +123,8 @@ class GenericElementDecoder[Acc, Result] private (state: DecoderState, logic: De
     fail(cursor.error(message))
   }
 
-  override def result(history: List[String]): Either[DecodingError, Result] =
-    Left(DecodingError("Decoding not complete", history))
+  override def result(history: => List[String]): Either[DecodingError, Result] =
+    Left(ElementDecoder.decodingNotCompleteError(history))
 
   override val isCompleted: Boolean = false
 }

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/TextDecoder.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/TextDecoder.scala
@@ -22,7 +22,7 @@ import scala.annotation.tailrec
   */
 trait TextDecoder[A] { self =>
   def decodeAsText(c: Cursor): TextDecoder[A]
-  def result(history: List[String]): Either[DecodingError, A]
+  def result(history: => List[String]): Either[DecodingError, A]
   def isCompleted: Boolean
 
   def map[B](f: A => B): TextDecoder[B] = new MappedDecoder(self, f)
@@ -37,7 +37,7 @@ object TextDecoder extends TextLiteralInstances {
     def decodeAsText(c: Cursor): TextDecoder[B] =
       new MappedDecoder[A, B](fa.decodeAsText(c), f)
 
-    def result(history: List[String]): Either[DecodingError, B] = fa.result(history).map(f)
+    def result(history: => List[String]): Either[DecodingError, B] = fa.result(history).map(f)
 
     val isCompleted: Boolean = fa.isCompleted
 
@@ -50,7 +50,7 @@ object TextDecoder extends TextLiteralInstances {
     def decodeAsText(c: Cursor): TextDecoder[B] =
       new EMappedDecoder(fa.decodeAsText(c), f)
 
-    def result(history: List[String]): Either[DecodingError, B] = fa.result(history) match {
+    def result(history: => List[String]): Either[DecodingError, B] = fa.result(history) match {
       case Right(a)    => f(history, a)
       case Left(error) => Left(error)
     }
@@ -66,7 +66,7 @@ object TextDecoder extends TextLiteralInstances {
   final class ConstDecoder[A](a: A) extends TextDecoder[A] {
     def decodeAsText(c: Cursor): TextDecoder[A] = this
 
-    def result(history: List[String]): Either[DecodingError, A] = Right(a)
+    def result(history: => List[String]): Either[DecodingError, A] = Right(a)
 
     val isCompleted: Boolean = true
 
@@ -76,7 +76,7 @@ object TextDecoder extends TextLiteralInstances {
   final class FailedDecoder[A](decodingError: DecodingError) extends TextDecoder[A] {
     def decodeAsText(c: Cursor): TextDecoder[A] = this
 
-    def result(history: List[String]): Either[DecodingError, A] = Left(decodingError)
+    def result(history: => List[String]): Either[DecodingError, A] = Left(decodingError)
 
     val isCompleted: Boolean = true
 
@@ -101,7 +101,7 @@ object TextDecoder extends TextLiteralInstances {
       go()
     }
 
-    def result(history: List[String]): Either[DecodingError, String] =
+    def result(history: => List[String]): Either[DecodingError, String] =
       Right(string)
 
     val isCompleted: Boolean = true

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/derivation/DecoderDerivation.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/derivation/DecoderDerivation.scala
@@ -90,8 +90,8 @@ class DecoderDerivation(ctx: blackbox.Context) extends Derivation(ctx) {
         
         val isCompleted: $scalaPkg.Boolean = false
 
-        def result(history: $scalaPkg.List[$javaPkg.String]): $scalaPkg.Either[$decodingPkg.DecodingError, $classType] =
-          $scalaPkg.Left($decodingPkg.DecodingError("Decoding not complete", history))
+        def result(history: => $scalaPkg.List[$javaPkg.String]): $scalaPkg.Either[$decodingPkg.DecodingError, $classType] =
+          $scalaPkg.Left($decodingPkg.ElementDecoder.decodingNotCompleteError(history))
       }
     """
   }
@@ -154,7 +154,7 @@ class DecoderDerivation(ctx: blackbox.Context) extends Derivation(ctx) {
               defaultValue = q"$derivationPkg.CallByNeed[$elementDecoder]($ref)",
               goAssignment = q"var $tempName: $elementDecoder = $paramName.value",
               decoderConstructionParam = q"$derivationPkg.CallByNeed[$elementDecoder]($tempName)",
-              classConstructionForEnum = fq"$forName <- $tempName.result(localName :: cursor.history)",
+              classConstructionForEnum = fq"$forName <- $tempName.result($xmlNameVal :: localName :: cursor.history)",
               classConstructorParam = q"$forName",
             ),
           )
@@ -363,8 +363,9 @@ class DecoderDerivation(ctx: blackbox.Context) extends Derivation(ctx) {
           go(state)
         }
 
-        def result(history: $scalaPkg.List[$javaPkg.String]): $scalaPkg.Either[$decodingPkg.DecodingError, $classType] =
-          $scalaPkg.Left($decodingPkg.DecodingError("Decoding not complete", history))
+        def result(history: => $scalaPkg.List[$javaPkg.String]): $scalaPkg.Either[$decodingPkg.DecodingError, $classType] = {
+          $scalaPkg.Left($decodingPkg.ElementDecoder.decodingNotCompleteError(history))
+        }
 
         val isCompleted: $scalaPkg.Boolean = false
       }


### PR DESCRIPTION
Closes #108 

This PR improves error messages. 

Here is an example of new error messages:
```scala
import ru.tinkoff.phobos.decoding.XmlDecoder
import ru.tinkoff.phobos.annotations.{ElementCodec, XmlCodec}
import ru.tinkoff.phobos.configured.ElementCodecConfig

@XmlCodec("a", ElementCodecConfig.default.withDiscriminator("type", None))
sealed trait A
@ElementCodec
final case class A1(b1: String, c1: C1) extends A
@ElementCodec
final case class C1(d1: Int, e1: E1)
@ElementCodec
final case class E1(f1: Char, g1: String, h1: Int)
@ElementCodec
final case class A2(b2: String, c2: C2) extends A
@ElementCodec(ElementCodecConfig.default.withDiscriminator("type", None))
sealed trait C2
@ElementCodec
final case class C21(f21: Char, g21: String, h21: Int) extends C2
@ElementCodec
final case class C22(f22: Char, g22: String, h22: Int) extends C2

val a1 =
    """<?xml version='1.0' encoding='UTF-8'?>
    |<a type="A1">
    |  <b1>b1</b1>
    |  <c1>
    |    <d1>35</d1>
    |    <e1>
    |      <f1>b</f1>
    |      <h1>1</h1>
    |    </e1>
    |  </c1>
    |</a>
    |""".stripMargin

println(XmlDecoder[A].decode(a1))
```
It will print
```
Left(ru.tinkoff.phobos.decoding.DecodingError: Error while decoding XML: Element 'g1' is missing or invalid
	In element 'e1'
		in element 'c1'
		in element 'a'
     )
```
Previously it would have printed
```
Left(ru.tinkoff.phobos.decoding.DecodingError: Error while decoding XML: Decoding not complete
	In element 'e1'
		in element 'c1'
		in element 'a'
     )
```