### PR TITLE
Formatted date/time codecs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,11 @@ src_managed/
 project/boot/
 project/plugins/project/
 .sbt
+.bloop/
+project/.bloop/
+project/project/.bloop/
+.metals/
+metals.sbt
 
 # Scala-IDE specific
 .scala_dependencies

--- a/modules/akka-http/src/test/scala/ru/tinkoff/phobos/akka_http/SoapTest.scala
+++ b/modules/akka-http/src/test/scala/ru/tinkoff/phobos/akka_http/SoapTest.scala
@@ -3,7 +3,7 @@ package ru.tinkoff.phobos.akka_http
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
 
-class SoapSuit extends AnyWordSpec with Matchers {
+class SoapTest extends AnyWordSpec with Matchers {
   "Soap codecs" should {
     "be found for envelope" in {
       """

--- a/modules/ast/src/test/scala/ru/tinkoff/phobos/ast/XmlEntryElementDecoderTest.scala
+++ b/modules/ast/src/test/scala/ru/tinkoff/phobos/ast/XmlEntryElementDecoderTest.scala
@@ -9,7 +9,7 @@ import ru.tinkoff.phobos.Namespace
 import ru.tinkoff.phobos.decoding.{DecodingError, XmlDecoder}
 import cats.syntax.either._
 
-class XmlEntryElementDecoderSpec extends AnyWordSpec with Matchers with DiffMatcher with EitherValues {
+class XmlEntryElementDecoderTest extends AnyWordSpec with Matchers with DiffMatcher with EitherValues {
 
   "XmlEntry decoder" should {
     "decodes simple Xml into ast correctly" in {

--- a/modules/ast/src/test/scala/ru/tinkoff/phobos/ast/XmlEntryElementEncoderTest.scala
+++ b/modules/ast/src/test/scala/ru/tinkoff/phobos/ast/XmlEntryElementEncoderTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.wordspec.AnyWordSpec
 import ru.tinkoff.phobos.Namespace
 import ru.tinkoff.phobos.encoding.XmlEncoder
 
-class XmlEntryElementEncoderSpec extends AnyWordSpec with DiffMatcher with Matchers {
+class XmlEntryElementEncoderTest extends AnyWordSpec with DiffMatcher with Matchers {
   "XmlEntry encoder" should {
     "encodes simple Xml ast correctly" in {
       val ast = xml(attr("foo") := 5, node("bar") := "bazz")

--- a/modules/ast/src/test/scala/ru/tinkoff/phobos/raw/FlattenElementsDecoderTest.scala
+++ b/modules/ast/src/test/scala/ru/tinkoff/phobos/raw/FlattenElementsDecoderTest.scala
@@ -6,7 +6,7 @@ import ru.tinkoff.phobos.Namespace
 import ru.tinkoff.phobos.decoding.XmlDecoder
 import ru.tinkoff.phobos.ast._
 
-class FlattenElementsDecoderSpec extends AnyWordSpec with Matchers {
+class FlattenElementsDecoderTest extends AnyWordSpec with Matchers {
 
   "XmlEntry decoder" should {
     "decodes simple Xml into ast correctly" in {

--- a/modules/ast/src/test/scala/ru/tinkoff/phobos/traverse/GenericElementDecoderTest.scala
+++ b/modules/ast/src/test/scala/ru/tinkoff/phobos/traverse/GenericElementDecoderTest.scala
@@ -9,8 +9,8 @@ import org.scalatest.wordspec.AnyWordSpec
 import ru.tinkoff.phobos.ast.XmlLeaf
 import ru.tinkoff.phobos.decoding.{DecodingError, ElementDecoder, XmlDecoder}
 
-class GenericElementDecoderSpec extends AnyWordSpec with Matchers with DiffMatcher with EitherValues {
-  import GenericElementDecoderSpec._
+class GenericElementDecoderTest extends AnyWordSpec with Matchers with DiffMatcher with EitherValues {
+  import GenericElementDecoderTest._
   "GenericElementDecoder" should {
     "work correctly with immutable accumulators" in {
       implicit val decodeAllAttributes: ElementDecoder[Acc] = GenericElementDecoder(ImmutableTraversalLogic)
@@ -41,7 +41,7 @@ class GenericElementDecoderSpec extends AnyWordSpec with Matchers with DiffMatch
   }
 }
 
-object GenericElementDecoderSpec {
+object GenericElementDecoderTest {
   case class Acc(attributes: Map[String, String])
 
   object ImmutableTraversalLogic extends DecodingTraversalLogic[Acc, Acc] {

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/ElementDecoder.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/decoding/ElementDecoder.scala
@@ -9,6 +9,7 @@ import ru.tinkoff.phobos.decoding.ElementDecoder.{EMappedDecoder, MappedDecoder}
 
 import scala.annotation.tailrec
 import scala.collection.mutable.ListBuffer
+import java.time.format.DateTimeFormatter
 
 /** Warning! This is a complicated internal API which may change in future. Do not implement or use this trait directly
   * unless you know what you are doing.
@@ -294,12 +295,24 @@ object ElementDecoder extends ElementLiteralInstances {
   implicit val localDateTimeDecoder: ElementDecoder[LocalDateTime] =
     stringDecoder.emap(wrapException(LocalDateTime.parse))
 
+  def localDateTimeDecoderWithFormatter(formatter: DateTimeFormatter): ElementDecoder[LocalDateTime] =
+    stringDecoder.emap(wrapException(LocalDateTime.parse(_, formatter)))
+
   implicit val zonedDateTimeDecoder: ElementDecoder[ZonedDateTime] =
     stringDecoder.emap(wrapException(ZonedDateTime.parse))
+
+  def zonedDateTimeDecoderWithFormatter(formatter: DateTimeFormatter): ElementDecoder[ZonedDateTime] =
+    stringDecoder.emap(wrapException(ZonedDateTime.parse(_, formatter)))
 
   implicit val localDateDecoder: ElementDecoder[LocalDate] =
     stringDecoder.emap(wrapException(LocalDate.parse))
 
+  def localDateDecoderWithFormatter(formatter: DateTimeFormatter): ElementDecoder[LocalDate] =
+    stringDecoder.emap(wrapException(LocalDate.parse(_, formatter)))
+
   implicit val localTimeDecoder: ElementDecoder[LocalTime] =
     stringDecoder.emap(wrapException(LocalTime.parse))
+
+  def localTimeDecoderWithFormatter(formatter: DateTimeFormatter): ElementDecoder[LocalTime] =
+    stringDecoder.emap(wrapException(LocalTime.parse(_, formatter)))
 }

--- a/modules/core/src/main/scala/ru/tinkoff/phobos/encoding/ElementEncoder.scala
+++ b/modules/core/src/main/scala/ru/tinkoff/phobos/encoding/ElementEncoder.scala
@@ -2,6 +2,7 @@ package ru.tinkoff.phobos.encoding
 
 import java.time.{LocalDate, LocalDateTime, LocalTime, ZonedDateTime}
 import java.util.{Base64, UUID}
+import java.time.format.DateTimeFormatter
 
 /** Warning! This is an internal API which may change in future. Do not implement or use this trait directly unless you
   * know what you are doing.
@@ -106,12 +107,24 @@ object ElementEncoder extends ElementLiteralInstances {
   implicit val localDateTimeEncoder: ElementEncoder[LocalDateTime] =
     stringEncoder.contramap(_.toString)
 
+  def localDateTimeEncoderWithFormatter(formatter: DateTimeFormatter): ElementEncoder[LocalDateTime] = 
+    stringEncoder.contramap(_.format(formatter))
+
   implicit val zonedDateTimeEncoder: ElementEncoder[ZonedDateTime] =
     stringEncoder.contramap(_.toString)
+
+  def zonedDateTimeEncoderWithFormatter(formatter: DateTimeFormatter): ElementEncoder[ZonedDateTime] =
+    stringEncoder.contramap(_.format(formatter))
 
   implicit val localDateEncoder: ElementEncoder[LocalDate] =
     stringEncoder.contramap(_.toString)
 
+  def localDateEncoderWithFormatter(formatter: DateTimeFormatter): ElementEncoder[LocalDate] =
+    stringEncoder.contramap(_.format(formatter))
+
   implicit val localTimeEncoder: ElementEncoder[LocalTime] =
     stringEncoder.contramap(_.toString)
+
+  def localTimeEncoderWithFormatter(formatter: DateTimeFormatter): ElementEncoder[LocalTime] = 
+    stringEncoder.contramap(_.format(formatter))
 }

--- a/modules/core/src/test/scala-2.13/ru/tinkoff/phobos/LiteralDecodingTest.scala
+++ b/modules/core/src/test/scala-2.13/ru/tinkoff/phobos/LiteralDecodingTest.scala
@@ -7,7 +7,7 @@ import ru.tinkoff.phobos.annotations.XmlCodec
 import ru.tinkoff.phobos.decoding.{DecodingError, XmlDecoder}
 import ru.tinkoff.phobos.syntax.{attr, text}
 
-class LiteralDecodingSuit extends AnyWordSpec with Matchers {
+class LiteralDecodingTest extends AnyWordSpec with Matchers {
   def pure(str: String): List[Array[Byte]] =
     List(str.getBytes("UTF-8"))
 

--- a/modules/core/src/test/scala-2.13/ru/tinkoff/phobos/LiteralEncodingTest.scala
+++ b/modules/core/src/test/scala-2.13/ru/tinkoff/phobos/LiteralEncodingTest.scala
@@ -6,7 +6,7 @@ import ru.tinkoff.phobos.encoding.XmlEncoder
 import ru.tinkoff.phobos.syntax.{attr, text}
 import ru.tinkoff.phobos.testString._
 
-class LiteralEncodingSuit extends AnyWordSpec {
+class LiteralEncodingTest extends AnyWordSpec {
   "Literal encoders" should {
     "encode attributes with literal type" in {
       @XmlCodec("foo")

--- a/modules/core/src/test/scala/ru/tinkoff/phobos/DecoderDerivationTest.scala
+++ b/modules/core/src/test/scala/ru/tinkoff/phobos/DecoderDerivationTest.scala
@@ -10,7 +10,7 @@ import ru.tinkoff.phobos.syntax._
 import ru.tinkoff.phobos.configured.naming._
 import ru.tinkoff.phobos.configured.ElementCodecConfig
 
-class DecoderDerivationSuit extends AnyWordSpec with Matchers {
+class DecoderDerivationTest extends AnyWordSpec with Matchers {
   def pure(str: String): List[Array[Byte]] =
     List(str.getBytes("UTF-8"))
 

--- a/modules/core/src/test/scala/ru/tinkoff/phobos/EncoderDerivationTest.scala
+++ b/modules/core/src/test/scala/ru/tinkoff/phobos/EncoderDerivationTest.scala
@@ -10,7 +10,7 @@ import ru.tinkoff.phobos.syntax._
 import ru.tinkoff.phobos.configured.naming._
 import ru.tinkoff.phobos.configured.ElementCodecConfig
 
-class EncoderDerivationSuit extends AnyWordSpec with Matchers {
+class EncoderDerivationTest extends AnyWordSpec with Matchers {
 
   "Encoder derivation without namespaces" should {
     "encode simple case classes" in {

--- a/modules/derevo/src/test/scala/ru/tinkoff/phobos/derevo/DerevoTest.scala
+++ b/modules/derevo/src/test/scala/ru/tinkoff/phobos/derevo/DerevoTest.scala
@@ -3,7 +3,7 @@ package ru.tinkoff.phobos.derevo
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
 
-class DerevoSuit extends AnyWordSpec with Matchers {
+class DerevoTest extends AnyWordSpec with Matchers {
   "Derevo" should {
     "derive xml encoder without namespace" in {
       """

--- a/modules/enumeratum/src/test/scala/ru/tinkoff/phobos/enumeratum/EnumeratumTest.scala
+++ b/modules/enumeratum/src/test/scala/ru/tinkoff/phobos/enumeratum/EnumeratumTest.scala
@@ -10,7 +10,7 @@ import ru.tinkoff.phobos.encoding.XmlEncoder
 import ru.tinkoff.phobos.syntax._
 import ru.tinkoff.phobos.testString._
 
-class EnumeratumSuit extends AnyWordSpec with Matchers {
+class EnumeratumTest extends AnyWordSpec with Matchers {
   "Enum codecs" should {
     "encode enums" in {
       sealed trait Foo extends EnumEntry with Product with Serializable

--- a/modules/refined/src/test/scala/ru/tinkoff/phobos/refined/RefinedDecodersTest.scala
+++ b/modules/refined/src/test/scala/ru/tinkoff/phobos/refined/RefinedDecodersTest.scala
@@ -12,7 +12,7 @@ import ru.tinkoff.phobos.syntax.{attr, text}
 import ru.tinkoff.phobos.testString._
 import shapeless.{Witness => W}
 
-class RefinedDecodersSpec extends AnyWordSpec with Matchers {
+class RefinedDecodersTest extends AnyWordSpec with Matchers {
   type NumericAtLeastTo = MatchesRegex[W.`"[0-9]{2,}"`.T]
 
   @XmlCodec("test")
@@ -54,7 +54,7 @@ class RefinedDecodersSpec extends AnyWordSpec with Matchers {
       XmlDecoder[Qux].decode(sampleXml) shouldEqual Right(expectedResult)
     }
 
-    "provide verbose errorst" in {
+    "provide verbose errors" in {
 
       @XmlCodec("test")
       case class Test2(x: Int, y: Refined[String, NumericAtLeastTo])
@@ -75,7 +75,7 @@ class RefinedDecodersSpec extends AnyWordSpec with Matchers {
         .decode(sampleXml0)
         .left
         .map(_.text) shouldEqual Left(
-        """Failed to verify RefinedDecodersSpec.this.NumericAtLeastTo refinement for value=1 of raw type String: Predicate failed: "1".matches("[0-9]{2,}").""",
+        """Failed to verify RefinedDecodersTest.this.NumericAtLeastTo refinement for value=1 of raw type String: Predicate failed: "1".matches("[0-9]{2,}").""",
       )
 
       val sampleXml1 =

--- a/modules/refined/src/test/scala/ru/tinkoff/phobos/refined/RefinedEncodersTest.scala
+++ b/modules/refined/src/test/scala/ru/tinkoff/phobos/refined/RefinedEncodersTest.scala
@@ -12,7 +12,7 @@ import ru.tinkoff.phobos.syntax.{attr, text}
 import shapeless.{Witness => W}
 import ru.tinkoff.phobos.testString._
 
-class RefinedEncodersSpec extends AnyWordSpec with Matchers {
+class RefinedEncodersTest extends AnyWordSpec with Matchers {
   type NumericAtLeastTo = MatchesRegex[W.`"[0-9]{2,}"`.T]
 
   @XmlCodec("test")


### PR DESCRIPTION
This PR lands support of java date/time codecs with custom `DateTimeFormatter`s

Also, all test suits renamed to the style `.*Test.scala`